### PR TITLE
Fix setup, add CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: CI Build
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - "**"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Install
+        run: |
+          pip install -r requirements.txt
+          pip install -e .

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup
 from os import path
 
 current_folder = path.abspath(path.dirname(__file__))
-long_description = open('%s\\README.md' % current_folder, encoding='utf-8').read()
+long_description = open(path.join(current_folder, 'README.MD'), encoding='utf-8').read()
 
 # https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/
 setup(
     name="pizzoo",
-    version="0.9.12",
+    version="0.9.13",
     author="Pablo Huet",
     description="Pizzoo is a easy-to-use library for rendering on pixel matrix screens like the Pixoo64, featuring easy new device integration, animation tools, and XML template rendering support.",
     long_description=long_description,


### PR DESCRIPTION
Hello, nice project! This PR fixes the issues with setup.py when using pip install or pip install -e .

Error:
```
pip install -e .
Obtaining file:///home/guspuffy/third-party/pizzoo
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [7 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/guspuffy/third-party/pizzoo/setup.py", line 5, in <module>
          long_description = open('%s\\README.md' % current_folder, encoding='utf-8').read()
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      FileNotFoundError: [Errno 2] No such file or directory: '/home/guspuffy/third-party/pizzoo\\README.md'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

Here is a passing build using the fixed setup: https://github.com/guspuffygit/pizzoo/actions/runs/11758417179/job/32756772994