### PR TITLE
add README.MD to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include *.bdf
+include *.bdf README.MD


### PR DESCRIPTION
This is necessary for reading the README from setup.py while building from the sdist (which happens during `uv add pizzoo`).

Actual fix for https://github.com/pabletos/pizzoo/issues/5