### PR TITLE
be less strict about dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ setup(
 	package_dir={'pizzoo': 'pizzoo'},
 	package_data={'pizzoo': ['*.bdf']},
     install_requires=[
-        'requests ~= 2.31.0',
-        'Pillow ~= 11.1.0',
-		'bdfparser ~= 2.2.0'
+        'requests >= 2.31.0',
+        'Pillow >= 11.1.0',
+		'bdfparser >= 2.2.0'
     ],
 	classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
otherwise it's hard to use pizzoo in projects that have their own dependencies on Pillow or requests